### PR TITLE
move to parameterized classes

### DIFF
--- a/lib/puppet/functions/chromedriver/fetch_latest_version.rb
+++ b/lib/puppet/functions/chromedriver/fetch_latest_version.rb
@@ -1,8 +1,12 @@
 require 'open-uri'
 
 Puppet::Functions.create_function(:'chromedriver::fetch_latest_version') do
-  def fetch_latest_version
-    open('https://chromedriver.storage.googleapis.com/LATEST_RELEASE') do |f|
+  dispatch :fetch_latest_version do
+    optional_param 'String', :source
+  end
+
+  def fetch_latest_version(source = 'https://chromedriver.storage.googleapis.com')
+    open("#{source}/LATEST_RELEASE") do |f|
       f.read
     end
   rescue SocketError

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,10 +5,16 @@
 # @example
 #   include chromedriver
 class chromedriver (
-  String $version     = $::chromedriver::params::version,
-  String $install_dir = $::chromedriver::params::install_dir,
+  String               $version     = $::chromedriver::params::version,
+  Stdlib::Absolutepath $install_dir = $::chromedriver::params::install_dir,
+  Stdlib::Absolutepath $link_target = $::chromedriver::params::link_target,
+  Stdlib::Httpurl      $source      = $::chromedriver::params::source,
 ) inherits ::chromedriver::params {
 
-  include ::chromedriver::install
-
+  class { '::chromedriver::install':
+    version     => $version,
+    install_dir => $install_dir,
+    link_target => $link_target,
+    source      => $source,
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,51 +4,51 @@
 #
 # @example
 #   include chromedriver::install
-class chromedriver::install {
-  include ::chromedriver::params
+class chromedriver::install (
+  String               $version     = $::chromedriver::params::version,
+  Stdlib::Absolutepath $install_dir = $::chromedriver::params::install_dir,
+  Stdlib::Absolutepath $link_target = $::chromedriver::params::link_target,
+  Stdlib::Httpurl      $source      = $::chromedriver::params::source,
+) inherits ::chromedriver::params {
 
   $packages = ['libgconf2-dev', 'libxi-dev', 'unzip', 'libnss3-dev']
   ensure_packages($packages, {'ensure' => 'present'})
 
-  $latest = chromedriver::fetch_latest_version()
+  $latest = chromedriver::fetch_latest_version($source)
 
   if !$latest {
     fail('Unable to get latest chromedriver version')
   }
 
-  if $::chromedriver::version == 'latest' {
+  if $version == 'latest' {
     $desired_version = $latest
   } else {
-    $desired_version = $::chromedriver::version
+    $desired_version = $version
   }
 
-  $platform = "${::chromedriver::params::platform}${::chromedriver::params::arch}"
-
   if !$facts['chromedriver_version'] or (versioncmp($desired_version, $facts['chromedriver_version']) != 0) {
-    $version_dir = "${::chromedriver::install_dir}/${desired_version}"
+    $version_dir = "${install_dir}/${desired_version}"
 
     file { $version_dir:
       ensure  => 'directory',
-      require => File[$::chromedriver::install_dir],
+      require => File[$install_dir],
     } -> archive { "/tmp/chromedriver-${desired_version}.zip":
       ensure       => 'present',
-      source       => "${::chromedriver::params::source}/${desired_version}/chromedriver_${platform}.zip",
-
+      source       => "${source}/${desired_version}/chromedriver_${platform}${arch}.zip", #lint:ignore:variable_scope
       extract      => true,
       extract_path => $version_dir,
       cleanup      => true,
       creates      => "${version_dir}/chromedriver",
-
       require      => Package['unzip'],
     } -> file { "${version_dir}/chromedriver":
       mode   => '0755',
-    } -> file { '/usr/local/bin/chromedriver':
+    } -> file { $link_target:
       ensure => 'link',
       target => "${version_dir}/chromedriver",
     }
   }
 
-  file { $::chromedriver::install_dir:
+  file { $install_dir:
     ensure => 'directory',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,4 +26,5 @@ class chromedriver::params {
   }
 
   $source = 'https://chromedriver.storage.googleapis.com'
+  $link_target = '/usr/local/bin/chromedriver'
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe 'chromedriver::install' do
   after(:each) { Facter.clear }
-  let(:facts) { { 'chromedriver_version' => nil } }
+  let(:facts) do
+    {
+      chromedriver_version: nil,
+    }
+  end
 
   describe 'when unable to fetch chromedriver versions' do
-    let(:pre_condition) { 'include ::chromedriver' }
-
     before(:each) do
       allow(OpenURI).to receive(:open_uri)
         .with(URI::HTTPS.build(host: 'chromedriver.storage.googleapis.com', path: '/LATEST_RELEASE'))
@@ -17,18 +19,16 @@ describe 'chromedriver::install' do
   end
 
   on_supported_os.each do |os, os_facts|
-    let(:pre_condition) { 'include ::chromedriver' }
-
     context "on #{os}" do
-      let(:facts) { os_facts }
+      let(:facts) do
+        os_facts
+      end
 
       it { is_expected.to compile }
     end
   end
 
   describe 'creates required resources' do
-    let(:pre_condition) { 'include ::chromedriver' }
-
     it {
       is_expected.to contain_file('/opt/chromedriver')
         .with_ensure('directory')
@@ -51,8 +51,10 @@ describe 'chromedriver::install' do
   end
 
   describe 'latest chromedriver' do
-    let(:pre_condition) do
-      'class { "chromedriver": version => "latest" }'
+    let(:params) do
+      {
+        version: 'latest',
+      }
     end
 
     describe 'with no chromedriver installed' do
@@ -63,7 +65,11 @@ describe 'chromedriver::install' do
     end
 
     describe 'when installed chromedriver version is lower' do
-      let(:facts) { { 'chromedriver_version' => '1.0' } }
+      let(:facts) do
+        {
+          chromedriver_version: '1.0',
+        }
+      end
 
       it {
         is_expected.to contain_archive('/tmp/chromedriver-2.11.zip')
@@ -72,15 +78,21 @@ describe 'chromedriver::install' do
     end
 
     describe 'when installed chromedriver version equals latest version' do
-      let(:facts) { { 'chromedriver_version' => '2.11' } }
+      let(:facts) do
+        {
+          chromedriver_version: '2.11',
+        }
+      end
 
       it { is_expected.not_to contain_archive('/tmp/chromedriver-2.11.zip') }
     end
   end
 
   describe 'specific chromedriver version' do
-    let(:pre_condition) do
-      'class { "chromedriver": version => "2.1" }'
+    let(:params) do
+      {
+        version: '2.1',
+      }
     end
 
     describe 'with no chromedriver installed' do
@@ -91,7 +103,11 @@ describe 'chromedriver::install' do
     end
 
     describe 'when installed chromedriver version is lower' do
-      let(:facts) { { 'chromedriver_version' => '1.0' } }
+      let(:facts) do
+        {
+          chromedriver_version: '1.0',
+        }
+      end
 
       it {
         is_expected.to contain_archive('/tmp/chromedriver-2.1.zip')
@@ -100,7 +116,11 @@ describe 'chromedriver::install' do
     end
 
     describe 'when installed chromedriver version is higher' do
-      let(:facts) { { 'chromedriver_version' => '2.11' } }
+      let(:facts) do
+        {
+          chromedriver_version: '2.11',
+        }
+      end
 
       it {
         is_expected.to contain_archive('/tmp/chromedriver-2.1.zip')
@@ -109,14 +129,22 @@ describe 'chromedriver::install' do
     end
 
     describe 'when installed chromedriver version equals desired version' do
-      let(:facts) { { 'chromedriver_version' => '2.1' } }
+      let(:facts) do
+        {
+          chromedriver_version: '2.1',
+        }
+      end
 
       it { is_expected.not_to contain_archive('/tmp/chromedriver-2.1.zip') }
     end
   end
 
   describe 'with custom install directory' do
-    let(:pre_condition) { 'class { "chromedriver": install_dir => "/tmp/chromedriver" }' }
+    let(:params) do
+      {
+        install_dir: '/tmp/chromedriver',
+      }
+    end
 
     it {
       is_expected.to contain_file('/tmp/chromedriver')
@@ -141,6 +169,73 @@ describe 'chromedriver::install' do
     it {
       is_expected.to contain_file('/usr/local/bin/chromedriver')
         .with_target('/tmp/chromedriver/2.11/chromedriver')
+    }
+  end
+
+  describe 'with custom source' do
+    let(:params) do
+      {
+        source: 'https://some.custom.host',
+      }
+    end
+
+    describe 'when unable to fetch chromedriver versions' do
+      before(:each) do
+        allow(OpenURI).to receive(:open_uri)
+          .with(URI::HTTPS.build(host: 'some.custom.host', path: '/LATEST_RELEASE'))
+          .and_raise(SocketError)
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{Unable to get latest chromedriver version}) }
+    end
+    describe 'on succesfull call' do
+      before(:each) do
+        allow(OpenURI).to receive(:open_uri)
+          .with(URI::HTTPS.build(host: 'some.custom.host', path: '/LATEST_RELEASE'))
+          .and_return('2.11')
+      end
+      describe 'with no chromedriver installed' do
+        it {
+          is_expected.to contain_archive('/tmp/chromedriver-2.11.zip')
+            .with_source('https://some.custom.host/2.11/chromedriver_linux64.zip')
+        }
+      end
+
+      describe 'when installed chromedriver version is lower' do
+        let(:facts) do
+          {
+            chromedriver_version: '1.0',
+          }
+        end
+
+        it {
+          is_expected.to contain_archive('/tmp/chromedriver-2.11.zip')
+            .with_source('https://some.custom.host/2.11/chromedriver_linux64.zip')
+        }
+      end
+
+      describe 'when installed chromedriver version equals latest version' do
+        let(:facts) do
+          {
+            chromedriver_version: '2.11',
+          }
+        end
+
+        it { is_expected.not_to contain_archive('/tmp/chromedriver-2.11.zip') }
+      end
+    end
+  end
+
+  describe 'with custom link_target' do
+    let(:params) do
+      {
+        link_target: '/some/custom/target',
+      }
+    end
+
+    it {
+      is_expected.to contain_file('/some/custom/target')
+        .with_target('/opt/chromedriver/2.11/chromedriver')
     }
   end
 end

--- a/spec/functions/fetch_latest_version_spec.rb
+++ b/spec/functions/fetch_latest_version_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'chromedriver::fetch_latest_version' do
     end
 
     it { is_expected.to run.and_return('2.11') }
+    it { is_expected.to run.with_params('https://chromedriver.storage.googleapis.com').and_return('2.11') }
   end
 
   describe 'on failed call' do
@@ -19,5 +20,6 @@ RSpec.describe 'chromedriver::fetch_latest_version' do
     end
 
     it { is_expected.to run.and_return(nil) }
+    it { is_expected.to run.with_params('https://chromedriver.storage.googleapis.com').and_return(nil) }
   end
 end


### PR DESCRIPTION
We needed more flexibility in :
* choosing the source, so we can use a local mirror
* where the symbolic link is created.